### PR TITLE
Add minikube support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_script:
   - "./tests/test-shellcheck.sh"
   - "./tests/test-yamllint.sh"
 
-script: docker run hello-world
+script: "./tests/test-minikube.sh"

--- a/kubernetes/drupal.yaml
+++ b/kubernetes/drupal.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: drupal
+  labels:
+    app: drupal
+spec:
+  ports:
+    - name: drupal-ui
+      port: 80
+      protocol: TCP
+      targetPort: 30080
+      nodePort: 30080
+  selector:
+    app: drupal
+    tier: frontend
+  type: NodePort
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: drupal-claim
+  labels:
+    app: drupal
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: drupal
+  labels:
+    app: drupal
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: drupal
+        tier: frontend
+    spec:
+      containers:
+        - image: drupal/drupal:latest
+          name: drupal
+          ports:
+            - containerPort: 30080
+              name: drupal
+          volumeMounts:
+            - name: drupal
+              mountPath: /var/www/html/
+      volumes:
+        - name: drupal
+          persistentVolumeClaim:
+            claimName: drupal-claim

--- a/kubernetes/local-volumes.yaml
+++ b/kubernetes/local-volumes.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-volume-1
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/data/pv-1
+  persistentVolumeReclaimPolicy: Recycle
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-volume-2
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/data/pv-2
+  persistentVolumeReclaimPolicy: Recycle
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-volume-3
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/data/pv-3
+  persistentVolumeReclaimPolicy: Recycle

--- a/kubernetes/postgres.yaml
+++ b/kubernetes/postgres.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  labels:
+    app: drupal
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: drupal
+    tier: postgreSQL
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-claim
+  labels:
+    app: drupal
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: postgresql
+  labels:
+    app: drupal
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: drupal
+        tier: postgreSQL
+    spec:
+      containers:
+        - image: postgres:latest
+          name: postgresql
+          env:
+            - name: POSTGRES_USER
+              value: drupal
+            - name: POSTGRES_DB
+              value: drupal_production
+            - name: POSTGRES_PASSWORD
+              value: drupal
+          ports:
+            - containerPort: 5432
+              name: postgresql
+          volumeMounts:
+            - name: postgresql
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgresql
+          persistentVolumeClaim:
+            claimName: postgres-claim

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+kubectl create -f kubernetes/local-volumes.yaml
+kubectl create -f kubernetes/postgres.yaml
+kubectl create -f kubernetes/drupal.yaml
+kubectl get nodes
+kubectl get svc drupal

--- a/tests/test-minikube.sh
+++ b/tests/test-minikube.sh
@@ -1,0 +1,53 @@
+# Copyright [2018] IBM Corp. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+#!/bin/bash -ex
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")"/../scripts/resources.sh
+
+setup_minikube() {
+	export CHANGE_MINIKUBE_NONE_USER=true
+	curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+	curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+	sudo -E minikube start --vm-driver=none --kubernetes-version=v1.9.0
+	minikube update-context
+	JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+}
+
+kubectl_deploy() {
+	echo "Running scripts/quickstart.sh"
+	"$(dirname "$0")"/../scripts/quickstart.sh
+}
+
+verify_deploy(){
+	echo "Verifying deployment was successful"
+	if ! sleep 1 && curl -sS "$(kubectl get svc drupal | grep drupal | awk '{ print $2 }')":30080; then
+		test_failed "$0"
+	fi
+}
+
+main(){
+	if ! setup_minikube; then
+		test_failed "$0"
+	elif ! kubectl_deploy; then
+		test_failed "$0"
+	elif ! verify_deploy; then
+		test_failed "$0"
+	else
+		test_passed "$0"
+	fi
+}
+
+main "$@"


### PR DESCRIPTION
We now are testing via minikube in CI. Additionally, now drupal can be
run locally via minikube.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>