### PR TITLE
Add deploy to IBM Cloud button

### DIFF
--- a/.bluemix/deploy.json
+++ b/.bluemix/deploy.json
@@ -1,0 +1,126 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Sample Deploy Stage",
+    "description": "sample toolchain",
+    "longDescription": "The Delivery Pipeline automates continuous deployment.",
+    "type": "object",
+    "properties": {
+        "prod-region": {
+            "description": "The bluemix region",
+            "type": "string"
+        },
+        "prod-organization": {
+            "description": "The bluemix org",
+            "type": "string"
+        },
+       "prod-space": {
+            "description": "The bluemix space",
+            "type": "string"
+        },
+       "prod-app-name": {
+            "description": "The name of your Drupal app",
+            "type": "string"
+        },
+       "bluemix-user": {
+            "description": "Your Bluemix user ID",
+            "type": "string"
+        },
+       "bluemix-password": {
+            "description": "Your Bluemix Password",
+            "type": "string"
+        },
+       "bluemix-api-key": {
+            "description": "Required for **Federated ID** since Federated ID can't login with Bluemix user and password via Bluemix CLI. You can obtain your API_KEY via https://console.ng.bluemix.net/iam/#/apikeys by clicking **Create API key** (Each API key only can be viewed once).",
+            "type": "string"
+        },
+       "bluemix-cluster-account": {
+            "description": "The GUID of the Bluemix account where you created the cluster. Retrieve it with [bx iam accounts].",
+            "type": "string"
+        },
+       "bluemix-cluster-name": {
+            "description": "Your cluster name. Retrieve it with [bx cs clusters].",
+            "type": "string"
+        }
+    },
+    "required": ["prod-region", "prod-organization", "prod-space", "bluemix-cluster-name"],
+    "anyOf": [
+        {
+            "required": ["bluemix-user", "bluemix-password", "bluemix-cluster-account"]
+        },
+        {
+            "required": ["bluemix-api-key"]
+        }
+    ],
+    "form": [
+       {
+          "type": "validator",
+          "url": "/devops/setup/bm-helper/helper.html"
+       },
+        {
+          "type": "text",
+          "readonly": false,
+          "title": "Bluemix User ID",
+          "key": "bluemix-user"
+        },{
+          "type": "password",
+          "readonly": false,
+          "title": "Bluemix Password",
+          "key": "bluemix-password"
+        },{
+          "type": "password",
+          "readonly": false,
+          "title": "Bluemix API Key (Optional)",
+          "key": "bluemix-api-key"
+        },{
+          "type": "password",
+          "readonly": false,
+          "title": "Bluemix Cluster Account ID",
+          "key": "bluemix-cluster-account"
+        },{
+          "type": "text",
+          "readonly": false,
+          "title": "Bluemix Cluster Name",
+          "key": "bluemix-cluster-name"
+        },
+        {
+            "type": "table",
+            "columnCount": 4,
+            "widths": ["15%", "28%", "28%", "28%"],
+            "items": [
+                {
+                  "type": "label",
+                  "title": ""
+                },
+                {
+                  "type": "label",
+                  "title": "Region"
+                },
+                {
+                  "type": "label",
+                  "title": "Organization"
+                },
+                {
+                  "type": "label",
+                  "title": "Space"
+                },
+                {
+                  "type": "label",
+                  "title": "Production stage"
+                },
+                {
+                  "type": "select",
+                  "key": "prod-region"
+                },
+                {
+                  "type": "select",
+                  "key": "prod-organization"
+                },
+                {
+                  "type": "select",
+                  "key": "prod-space",
+                  "readonly": false
+                }
+            ]
+        }
+    ]
+}

--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -1,0 +1,59 @@
+---
+stages:
+  - name: BUILD
+    inputs:
+      - type: git
+        branch: master
+        service: ${SAMPLE_REPO}
+    triggers:
+      - type: commit
+    jobs:
+      - name: Build
+        type: builder
+        artifact_dir: ''
+        build_type: shell
+        script: |-
+          #!/bin/bash
+          bash -n *.sh
+  - name: DEPLOY
+    inputs:
+      - type: job
+        stage: BUILD
+        job: Build
+        dir_name: null
+    triggers:
+      - type: stage
+    properties:
+      - name: BLUEMIX_USER
+        type: text
+        value: ${BLUEMIX_USER}
+      - name: BLUEMIX_PASSWORD
+        type: secure
+        value: ${BLUEMIX_PASSWORD}
+      - name: BLUEMIX_ACCOUNT
+        type: secure
+        value: ${BLUEMIX_ACCOUNT}
+      - name: CLUSTER_NAME
+        type: text
+        value: ${CLUSTER_NAME}
+      - name: API_KEY
+        type: secure
+        value: ${API_KEY}
+    jobs:
+      - name: Deploy
+        type: deployer
+        target:
+          region_id: ${PROD_REGION_ID}
+          api_key: ${API_KEY}
+          kubernetes_cluster: ${PROD_CLUSTER_NAME}
+          application: Pipeline
+        script: |
+          #!/bin/bash
+          ./scripts/install.sh
+          ./scripts/bx_auth.sh
+          ./scripts/deploy.sh
+hooks:
+  - enabled: true
+    label: null
+    ssl_enabled: false
+    url: https://devops-api-integration.stage1.ng.bluemix.net/v1/messaging/webhook/publish

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -1,0 +1,49 @@
+---
+name: "Deploy Drupal on Kubernetes in Bluemix"
+description: "Toolchain to deploy Drupal on Kubernetes in Bluemix"
+version: 0.1
+image: data:image/svg+xml;base64,$file(toolchain.svg,base64)
+icon: data:image/svg+xml;base64,$file(icon.svg,base64)
+required:
+ - deploy
+ - sample-repo
+
+# Github repos
+sample-repo:
+ service_id: githubpublic
+ parameters:
+  repo_name: "{{name}}"
+  repo_url: https://github.com/mlangbehn/drupal-on-kubernetes-sample
+  type: clone
+  has_issues: false
+
+# Pipelines
+sample-build:
+ service_id: pipeline
+ parameters:
+  name: "{{name}}"
+  ui-pipeline: true
+  configuration:
+   content: $file(pipeline.yml)
+   env:
+    SAMPLE_REPO: "sample-repo"
+    CF_APP_NAME: "{{deploy.parameters.prod-app-name}}"
+    PROD_SPACE_NAME: "{{deploy.parameters.prod-space}}"
+    PROD_ORG_NAME: "{{deploy.parameters.prod-organization}}"
+    PROD_REGION_ID: "{{deploy.parameters.prod-region}}"
+    BLUEMIX_USER: "{{deploy.parameters.bluemix-user}}"
+    BLUEMIX_PASSWORD: "{{deploy.parameters.bluemix-password}}"
+    API_KEY: "{{deploy.parameters.bluemix-api-key}}"
+    BLUEMIX_ACCOUNT: "{{deploy.parameters.bluemix-cluster-account}}"
+    CLUSTER_NAME: "{{deploy.parameters.bluemix-cluster-name}}"
+   execute: true
+  services: ["sample-repo"]
+ hidden: [form, description]
+
+# Deployment
+deploy:
+ schema:
+  $ref: deploy.json
+ service-category: pipeline
+ parameters:
+  prod-app-name: "{{sample-repo.parameters.repo_name}}"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ When the reader has completed this Code Pattern, they will understand how to:
 
 ## Steps
 
+[![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/mlangbehn/drupal-on-kubernetes-sample)
+
 Follow these steps to run Drupal on Kubernetes.
 
 1. [Clone the repo](#1-clone-the-repo)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo "Create Drupal"
+IP_ADDR=$(bx cs workers "$CLUSTER_NAME" | grep Ready | awk '{ print $2 }')
+if [[ -z "$IP_ADDR" ]]; then
+	echo "$CLUSTER_NAME not created or workers not ready"
+	exit 1
+fi
+
+echo -e "Configuring vars"
+if ! exp=$(bx cs cluster-config "$CLUSTER_NAME" | grep export); then
+	echo "Cluster $CLUSTER_NAME not created or not ready."
+	exit 1
+fi
+eval "$exp"
+
+echo -e "Deleting previous version of Drupal if it exists"
+kubectl delete --ignore-not-found=true svc,pvc,deployment -l app=drupal
+kubectl delete --ignore-not-found=true -f kubernetes/local-volumes.yaml
+
+echo -e "Creating pods"
+kubectl create -f kubernetes/local-volumes.yaml
+kubectl create -f kubernetes/postgres.yaml
+kubectl create -f kubernetes/drupal.yaml
+kubectl get svc drupal
+
+echo "" && echo "View your Drupal website at http://$IP_ADDR:30080"
+
+echo "Note: Your Drupal may take up to 5 minutes to be fully functioning"


### PR DESCRIPTION
This change adds support for deploying to IBM Cloud via a button in
README.md to creates a toolchain and automatically deploys via the IBM
DevOps toolchain.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>